### PR TITLE
Fix build image failed

### DIFF
--- a/deploy/build/makefile
+++ b/deploy/build/makefile
@@ -6,13 +6,13 @@ all: docker ami
 docker:
 	go build \
 		--ldflags '-extldflags "-static"' \
-		-o ./docker/evml ./../../cmd/evml/ 
+		-o ./docker/evml ../../cmd/evml/ 
 	docker build -t mosaicnetworks/evm-lite:$(EVM_LITE_VERSION) \
 		-t mosaicnetworks/evm-lite:latest \
 		./docker/
 
 ami:
-	go build -o ami/evml ./../../cmd/evml/ && \
+	go build -o ami/evml ../../cmd/evml/ && \
 	packer build --var-file=ami/secret.json \
 				 --var 'evml_version=$(EVM_LITE_VERSION)-$(GIT_COMMIT)' \
 				  ami/template.json 

--- a/deploy/conf/babble/scripts/build-babble-conf.sh
+++ b/deploy/conf/babble/scripts/build-babble-conf.sh
@@ -24,7 +24,7 @@ do
 	echo "Generating key pair for node$i"
 	docker run \
 		-v $dest:/.babble \
-		--rm mosaicnetworks/babble keygen
+		--rm mosaicnetworks/babble:0.4.0 keygen
 	echo "$IPBASE$(($IPADD + $i)):$PORT" > $dest/addr
 done
 


### PR DESCRIPTION
To fix build image failed, correct the path and save the key pair
for each node config.